### PR TITLE
Upgrade to go 1.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine
+FROM golang:1.9.2-alpine
 MAINTAINER Frederic Lemay <frederic.lemay@amaysim.com.au>
 
 ENV GLIDE_VERSION=v0.12.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine
+FROM golang:1.9-alpine
 MAINTAINER Frederic Lemay <frederic.lemay@amaysim.com.au>
 
 ENV GLIDE_VERSION=v0.12.3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_VERSION = 1.9
+GO_VERSION = 1.9.2
 IMAGE_NAME ?= amaysim/golang:$(GO_VERSION)
 TAG = $(GO_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_VERSION = 1.8.3
+GO_VERSION = 1.9
 IMAGE_NAME ?= amaysim/golang:$(GO_VERSION)
 TAG = $(GO_VERSION)
 


### PR DESCRIPTION
Hi folks, many thanks for creating this image, it's very useful.

I found that I wanted this feature mentioned in the [go1.9 release notes](https://golang.org/doc/go1.9):

> Rows.Scan can now scan user-defined string types. Previously the package supported scanning into numeric types like type Int int64. It now also supports scanning into string types like type String string.

so I bumped the go version to 1.9.2 (latest stable version listed [here](https://golang.org/dl/)). Our codebase seems to work fine on the new version, so might be worth making it available for others.

Unfortunately the PR won't bring the tag from `make gitTag` along with it, so y'all will have to handle that step. 

Thanks for making this image!